### PR TITLE
반복 일정 등록 요청을 보낼 수 있다

### DIFF
--- a/src/main/java/org/rogarithm/notifyevent/service/RecurEventService.java
+++ b/src/main/java/org/rogarithm/notifyevent/service/RecurEventService.java
@@ -1,0 +1,11 @@
+package org.rogarithm.notifyevent.service;
+
+import org.rogarithm.notifyevent.service.dto.RecurEventAddDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RecurEventService {
+    public void add(RecurEventAddDto dto) {
+
+    }
+}

--- a/src/main/java/org/rogarithm/notifyevent/service/dto/RecurEventAddDto.java
+++ b/src/main/java/org/rogarithm/notifyevent/service/dto/RecurEventAddDto.java
@@ -1,0 +1,57 @@
+package org.rogarithm.notifyevent.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import org.rogarithm.notifyevent.web.request.RecurEventAddRequest;
+import org.rogarithm.notifyevent.web.request.RecurParams;
+import org.rogarithm.notifyevent.web.request.RecurType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RecurEventAddDto {
+    private static final Logger log = LoggerFactory.getLogger(RecurEventAddDto.class);
+
+    /*
+    RecurEventAddRequest 타입 객체를 RecurEventAddDto로 바꾸고, 이 dto 객체를
+    webClient로 외부 API 요청으로 넘길 때 필드명은 모두 snake case가 되어야 한다
+     */
+    @JsonProperty("desc")
+    private String desc;
+    @JsonProperty("recur_type")
+    private RecurType recurType;
+    @JsonProperty("recur_params")
+    private RecurParams recurParams;
+
+    public RecurEventAddDto(String desc, RecurType recurType, RecurParams recurParams) {
+        this.desc = desc;
+        this.recurType = recurType;
+        this.recurParams = recurParams;
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    public RecurType getRecurType() {
+        return recurType;
+    }
+
+    public RecurParams getRecurParams() {
+        return recurParams;
+    }
+
+    public static RecurEventAddDto from(RecurEventAddRequest request) {
+        ObjectMapper snakeCaseMapper = new ObjectMapper();
+        snakeCaseMapper.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
+
+        RecurParams recurParamsInSnakeCase = snakeCaseMapper.convertValue(request.getRecurParams(), RecurParams.class);
+        RecurEventAddDto dto = new RecurEventAddDto(
+                request.getDesc(),
+                request.getRecurType(),
+                recurParamsInSnakeCase
+        );
+
+        return dto;
+    }
+}

--- a/src/main/java/org/rogarithm/notifyevent/web/EventController.java
+++ b/src/main/java/org/rogarithm/notifyevent/web/EventController.java
@@ -1,10 +1,14 @@
 package org.rogarithm.notifyevent.web;
 
 import org.rogarithm.notifyevent.service.EventService;
+import org.rogarithm.notifyevent.service.RecurEventService;
 import org.rogarithm.notifyevent.service.dto.EventAddDto;
+import org.rogarithm.notifyevent.service.dto.RecurEventAddDto;
 import org.rogarithm.notifyevent.web.request.EventAddRequest;
 import org.rogarithm.notifyevent.web.request.RecurEventAddRequest;
 import org.rogarithm.notifyevent.web.response.EventGetResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,10 +24,14 @@ import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
 @RestController
 public class EventController {
-    private final EventService eventService;
+    private static final Logger log = LoggerFactory.getLogger(EventController.class);
 
-    public EventController(EventService eventService) {
+    private final EventService eventService;
+    private final RecurEventService recurEventService;
+
+    public EventController(EventService eventService, RecurEventService recurEventService) {
         this.eventService = eventService;
+        this.recurEventService = recurEventService;
     }
 
     @RequestMapping(method=POST, path="/events")
@@ -56,6 +64,6 @@ public class EventController {
 
     @RequestMapping(method=POST, path="/events/recur")
     public void addRecur(@RequestBody RecurEventAddRequest request) {
-        System.out.println(request);
+        recurEventService.add(RecurEventAddDto.from(request));
     }
 }

--- a/src/main/java/org/rogarithm/notifyevent/web/EventController.java
+++ b/src/main/java/org/rogarithm/notifyevent/web/EventController.java
@@ -3,6 +3,7 @@ package org.rogarithm.notifyevent.web;
 import org.rogarithm.notifyevent.service.EventService;
 import org.rogarithm.notifyevent.service.dto.EventAddDto;
 import org.rogarithm.notifyevent.web.request.EventAddRequest;
+import org.rogarithm.notifyevent.web.request.RecurEventAddRequest;
 import org.rogarithm.notifyevent.web.response.EventGetResponse;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -51,5 +52,10 @@ public class EventController {
             return eventService.findByDescription(description);
         }
         throw new HttpMessageNotReadableException("date and description are required");
+    }
+
+    @RequestMapping(method=POST, path="/events/recur")
+    public void addRecur(@RequestBody RecurEventAddRequest request) {
+        System.out.println(request);
     }
 }

--- a/src/main/java/org/rogarithm/notifyevent/web/request/RecurEventAddRequest.java
+++ b/src/main/java/org/rogarithm/notifyevent/web/request/RecurEventAddRequest.java
@@ -2,10 +2,10 @@ package org.rogarithm.notifyevent.web.request;
 
 public class RecurEventAddRequest {
     private String desc;
-    private String recurType;
+    private RecurType recurType;
     private RecurParams recurParams;
 
-    public RecurEventAddRequest(String desc, String recurType, RecurParams recurParams) {
+    public RecurEventAddRequest(String desc, RecurType recurType, RecurParams recurParams) {
         this.desc = desc;
         this.recurType = recurType;
         this.recurParams = recurParams;
@@ -18,7 +18,7 @@ public class RecurEventAddRequest {
         return desc;
     }
 
-    public String getRecurType() {
+    public RecurType getRecurType() {
         return recurType;
     }
 
@@ -26,17 +26,3 @@ public class RecurEventAddRequest {
         return recurParams;
     }
 }
-
-/*
-json 형태로 다음과 같은 요청을 보내면, spring이 적절하게 RecurEventAddRequest 타입 요청 객체로 바꿀 수 있다
-recurType을 enum으로 바꾸기
-
-{
-  "desc": "golf games",
-  "recur_type": "DayInMonth",
-  "recur_params": {
-    "day_idx": 1,
-    "cnt": 1
-  }
-}
- */

--- a/src/main/java/org/rogarithm/notifyevent/web/request/RecurEventAddRequest.java
+++ b/src/main/java/org/rogarithm/notifyevent/web/request/RecurEventAddRequest.java
@@ -1,0 +1,42 @@
+package org.rogarithm.notifyevent.web.request;
+
+public class RecurEventAddRequest {
+    private String desc;
+    private String recurType;
+    private RecurParams recurParams;
+
+    public RecurEventAddRequest(String desc, String recurType, RecurParams recurParams) {
+        this.desc = desc;
+        this.recurType = recurType;
+        this.recurParams = recurParams;
+    }
+
+    public RecurEventAddRequest() {
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    public String getRecurType() {
+        return recurType;
+    }
+
+    public RecurParams getRecurParams() {
+        return recurParams;
+    }
+}
+
+/*
+json 형태로 다음과 같은 요청을 보내면, spring이 적절하게 RecurEventAddRequest 타입 요청 객체로 바꿀 수 있다
+recurType을 enum으로 바꾸기
+
+{
+  "desc": "golf games",
+  "recur_type": "DayInMonth",
+  "recur_params": {
+    "day_idx": 1,
+    "cnt": 1
+  }
+}
+ */

--- a/src/main/java/org/rogarithm/notifyevent/web/request/RecurParams.java
+++ b/src/main/java/org/rogarithm/notifyevent/web/request/RecurParams.java
@@ -1,0 +1,22 @@
+package org.rogarithm.notifyevent.web.request;
+
+public class RecurParams {
+    private String dayIdx;
+    private String cnt;
+
+    public RecurParams(String dayIdx, String cnt) {
+        this.dayIdx = dayIdx;
+        this.cnt = cnt;
+    }
+
+    public RecurParams() {
+    }
+
+    public String getDayIdx() {
+        return dayIdx;
+    }
+
+    public String getCnt() {
+        return cnt;
+    }
+}

--- a/src/main/java/org/rogarithm/notifyevent/web/request/RecurType.java
+++ b/src/main/java/org/rogarithm/notifyevent/web/request/RecurType.java
@@ -1,0 +1,15 @@
+package org.rogarithm.notifyevent.web.request;
+
+public enum RecurType {
+    DAY_IN_MONTH("DAY_IN_MONTH");
+
+    private final String type;
+
+    RecurType(String type) {
+        this.type = type;
+    }
+
+    public static RecurType of(String type) {
+        return RecurType.valueOf(type);
+    }
+}

--- a/src/test/java/org/rogarithm/notifyevent/service/dto/EventAddDtoTest.java
+++ b/src/test/java/org/rogarithm/notifyevent/service/dto/EventAddDtoTest.java
@@ -1,8 +1,7 @@
-package org.rogarithm.notifyevent.web.dto;
+package org.rogarithm.notifyevent.service.dto;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.rogarithm.notifyevent.service.dto.EventAddDto;
 import org.rogarithm.notifyevent.web.request.EventAddRequest;
 import org.rogarithm.notifyevent.web.request.EventType;
 

--- a/src/test/java/org/rogarithm/notifyevent/service/dto/RecurEventAddDtoTest.java
+++ b/src/test/java/org/rogarithm/notifyevent/service/dto/RecurEventAddDtoTest.java
@@ -1,0 +1,33 @@
+package org.rogarithm.notifyevent.service.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import org.junit.jupiter.api.Test;
+import org.rogarithm.notifyevent.web.request.RecurEventAddRequest;
+import org.rogarithm.notifyevent.web.request.RecurParams;
+import org.rogarithm.notifyevent.web.request.RecurType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RecurEventAddDtoTest {
+
+    @Test
+    public void test_field_name_convention() throws JsonProcessingException {
+        RecurEventAddRequest request = new RecurEventAddRequest(
+                "golf games",
+                RecurType.DAY_IN_MONTH,
+                new RecurParams("1", "1")
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
+
+        RecurEventAddDto dto = RecurEventAddDto.from(request);
+        assertThat(objectMapper.writeValueAsString(dto))
+                .isEqualTo(
+                        "{\"desc\":\"golf games\",\"recur_type\":\"DAY_IN_MONTH\",\"recur_params\":{\"day_idx\":\"1\",\"cnt\":\"1\"}}"
+                );
+    }
+}

--- a/src/test/java/org/rogarithm/notifyevent/web/EventControllerTest.java
+++ b/src/test/java/org/rogarithm/notifyevent/web/EventControllerTest.java
@@ -1,5 +1,6 @@
 package org.rogarithm.notifyevent.web;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.rogarithm.notifyevent.model.Event;
 import org.rogarithm.notifyevent.service.EventService;
+import org.rogarithm.notifyevent.service.RecurEventService;
 import org.rogarithm.notifyevent.service.dto.EventAddDto;
 import org.rogarithm.notifyevent.web.request.*;
 import org.rogarithm.notifyevent.web.response.EventGetResponse;
@@ -29,6 +31,8 @@ class EventControllerTest {
 
     @Mock
     EventService eventService;
+    @Mock
+    RecurEventService recurEventService;
 
     @Nested
     @DisplayName("리소스 추가 핸들러")
@@ -105,7 +109,7 @@ class EventControllerTest {
 
         @DisplayName("반복되는 이벤트 등록 요청을 만들 수 있다")
         @Test
-        public void test_add_recur_event() {
+        public void test_add_recur_event() throws JsonProcessingException {
             RecurEventAddRequest request = new RecurEventAddRequest(
                     "golf games", RecurType.DAY_IN_MONTH,
                     new RecurParams("1", "1")

--- a/src/test/java/org/rogarithm/notifyevent/web/EventControllerTest.java
+++ b/src/test/java/org/rogarithm/notifyevent/web/EventControllerTest.java
@@ -11,10 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.rogarithm.notifyevent.model.Event;
 import org.rogarithm.notifyevent.service.EventService;
 import org.rogarithm.notifyevent.service.dto.EventAddDto;
-import org.rogarithm.notifyevent.web.request.EventAddRequest;
-import org.rogarithm.notifyevent.web.request.EventType;
-import org.rogarithm.notifyevent.web.request.RecurEventAddRequest;
-import org.rogarithm.notifyevent.web.request.RecurParams;
+import org.rogarithm.notifyevent.web.request.*;
 import org.rogarithm.notifyevent.web.response.EventGetResponse;
 
 import java.time.LocalDate;
@@ -110,7 +107,7 @@ class EventControllerTest {
         @Test
         public void test_add_recur_event() {
             RecurEventAddRequest request = new RecurEventAddRequest(
-                    "golf games", "DayInMonth",
+                    "golf games", RecurType.DAY_IN_MONTH,
                     new RecurParams("1", "1")
             );
 

--- a/src/test/java/org/rogarithm/notifyevent/web/EventControllerTest.java
+++ b/src/test/java/org/rogarithm/notifyevent/web/EventControllerTest.java
@@ -13,6 +13,8 @@ import org.rogarithm.notifyevent.service.EventService;
 import org.rogarithm.notifyevent.service.dto.EventAddDto;
 import org.rogarithm.notifyevent.web.request.EventAddRequest;
 import org.rogarithm.notifyevent.web.request.EventType;
+import org.rogarithm.notifyevent.web.request.RecurEventAddRequest;
+import org.rogarithm.notifyevent.web.request.RecurParams;
 import org.rogarithm.notifyevent.web.response.EventGetResponse;
 
 import java.time.LocalDate;
@@ -102,6 +104,17 @@ class EventControllerTest {
             eventController.add(request);
 
             Mockito.verify(eventService, Mockito.times(1)).add(EventAddDto.from(request));
+        }
+
+        @DisplayName("반복되는 이벤트 등록 요청을 만들 수 있다")
+        @Test
+        public void test_add_recur_event() {
+            RecurEventAddRequest request = new RecurEventAddRequest(
+                    "golf games", "DayInMonth",
+                    new RecurParams("1", "1")
+            );
+
+            eventController.addRecur(request);
         }
     }
 

--- a/src/test/java/org/rogarithm/notifyevent/web/request/RecurEventAddRequestTest.java
+++ b/src/test/java/org/rogarithm/notifyevent/web/request/RecurEventAddRequestTest.java
@@ -1,0 +1,25 @@
+package org.rogarithm.notifyevent.web.request;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecurEventAddRequestTest {
+    @Test
+    public void test_field_name_convention() throws JsonProcessingException {
+        RecurEventAddRequest request = new RecurEventAddRequest(
+                "golf games",
+                RecurType.DAY_IN_MONTH,
+                new RecurParams("1", "1")
+        );
+        ObjectMapper objectMapper = new ObjectMapper();
+        assertThat(objectMapper.writeValueAsString(request)).isEqualTo(
+                "{\"desc\":\"golf games\",\"recurType\":\"DAY_IN_MONTH\",\"recurParams\":{\"dayIdx\":\"1\",\"cnt\":\"1\"}}"
+        );
+        assertThat(objectMapper.writeValueAsString(request.getRecurParams())).isEqualTo(
+                "{\"dayIdx\":\"1\",\"cnt\":\"1\"}"
+        );
+    }
+}

--- a/src/test/java/org/rogarithm/notifyevent/web/request/RecurTypeTest.java
+++ b/src/test/java/org/rogarithm/notifyevent/web/request/RecurTypeTest.java
@@ -1,0 +1,26 @@
+package org.rogarithm.notifyevent.web.request;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecurTypeTest {
+
+    @DisplayName("문자열 형태의 반복 일정 타입을 enum 타입으로 변환할 수 있다")
+    @Test
+    public void convert_string_to_recur_type_enum() {
+        String type = "DAY_IN_MONTH";
+        RecurType recurType = RecurType.of(type);
+        assertThat(recurType).isEqualTo(RecurType.DAY_IN_MONTH);
+    }
+
+    @DisplayName("정의되지 않은 반복 일정 문자열일 경우 오류를 반환한다")
+    @Test
+    public void throw_exception_when_convert_nonexisting_recur_type_string() {
+        String type = "X";
+        Assertions.assertThatThrownBy(() -> RecurType.of(type))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
- ruby+sinatra로 만든 서버에서 제공하는 반복 일정 관련 연산을 쓰기 위해, 해당 외부 서버에 보내기 위한 요청 객체를 정의한다
- notify-event에서 구현하는 서버로 요청을 보낼 때는 camel case 형식 필드로 요청을 보내고, 이 요청을 ruby+sinatra 서버로 보낼 dto로 변환 시 snake case로 필드명을 변환한다
notify-event server로 보내는 요청 예:
```
curl -X POST http://localhost:8081/events/recur \
-H "Content-Type: application/json" \
-d '{
  "desc": "golf games",
  "recurType": "DAY_IN_MONTH",
  "recurParams": {
    "dayIdx": 1,
    "cnt": 1
  }
}'
```

ruby+sinatra로 보낼, dto로 변환한 요청 예:
```
{
  "desc":"golf games",
  "recur_type":"DAY_IN_MONTH",
  "recur_params": {
    "day_idx":"1",
    "cnt":"1"
  }
}
```