### PR TITLE
반복 일정 추가 요청을 처리할 수 있다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 
 	runtimeOnly 'com.h2database:h2:2.2.224'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/rogarithm/notifyevent/config/WebClientConfig.java
+++ b/src/main/java/org/rogarithm/notifyevent/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package org.rogarithm.notifyevent.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .build();
+    }
+}

--- a/src/main/java/org/rogarithm/notifyevent/service/RecurEventService.java
+++ b/src/main/java/org/rogarithm/notifyevent/service/RecurEventService.java
@@ -1,11 +1,50 @@
 package org.rogarithm.notifyevent.service;
 
 import org.rogarithm.notifyevent.service.dto.RecurEventAddDto;
+import org.rogarithm.notifyevent.web.response.RecurEventAddResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
 
 @Service
 public class RecurEventService {
-    public void add(RecurEventAddDto dto) {
+    private static final Logger log = LoggerFactory.getLogger(RecurEventService.class);
 
+    @Autowired
+    private WebClient webClient;
+
+    @Transactional
+    public RecurEventAddResponse add(RecurEventAddDto dto) {
+        WebClient.ResponseSpec retrieve = webClient.post()
+                .uri("http://localhost:4567/evts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(dto)
+                .retrieve();
+
+        Mono<RecurEventAddResponse> response = retrieve.bodyToMono(RecurEventAddResponse.class);
+
+        RecurEventAddResponse recurEventAddResponse = null;
+
+        try {
+            log.info("Attempting to block response...");
+            recurEventAddResponse = response.block();
+            log.info("Successfully retrieved response");
+        } catch (WebClientResponseException e) {
+            log.error("WebClientResponseException: ", e);
+            log.error("Full error cause: ", e.getCause());
+        }
+
+        if (recurEventAddResponse == null) {
+            throw new RuntimeException("Failed to retrieve a response from external server");
+        }
+
+        return recurEventAddResponse;
     }
 }

--- a/src/main/java/org/rogarithm/notifyevent/web/EventController.java
+++ b/src/main/java/org/rogarithm/notifyevent/web/EventController.java
@@ -7,6 +7,7 @@ import org.rogarithm.notifyevent.service.dto.RecurEventAddDto;
 import org.rogarithm.notifyevent.web.request.EventAddRequest;
 import org.rogarithm.notifyevent.web.request.RecurEventAddRequest;
 import org.rogarithm.notifyevent.web.response.EventGetResponse;
+import org.rogarithm.notifyevent.web.response.RecurEventAddResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -63,7 +64,7 @@ public class EventController {
     }
 
     @RequestMapping(method=POST, path="/events/recur")
-    public void addRecur(@RequestBody RecurEventAddRequest request) {
-        recurEventService.add(RecurEventAddDto.from(request));
+    public RecurEventAddResponse addRecur(@RequestBody RecurEventAddRequest request) {
+        return recurEventService.add(RecurEventAddDto.from(request));
     }
 }

--- a/src/main/java/org/rogarithm/notifyevent/web/response/RecurEventAddResponse.java
+++ b/src/main/java/org/rogarithm/notifyevent/web/response/RecurEventAddResponse.java
@@ -1,0 +1,18 @@
+package org.rogarithm.notifyevent.web.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RecurEventAddResponse {
+    @JsonProperty("evt_name")
+    private final String eventName;
+
+    @JsonCreator
+    public RecurEventAddResponse(@JsonProperty("evt_name") String eventName) {
+        this.eventName = eventName;
+    }
+
+    public String getEventName() {
+        return eventName;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8081
+
 spring:
   application:
     name: notifyevent


### PR DESCRIPTION
- 클라우드에 서버를 올리기 위해 서버 포트 번호를 바꾼다
- 이전 PR에서 구현한 요청 객체로 반복 일정 관련 연산을 처리하는 ruby+sinatra 서버에 반복 일정 추가 요청을 보낼 수 있도록 한다